### PR TITLE
Link parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ As soon as you push code to your Obsidian repository, it will trigget an action 
 ## Status and known issues:
 - [x] Transform Obsidian project in Gitbook project (naming and structure)
 - [x] Generate a valid SUMMARY.md
+- [x] Remove git related files and folders
 - [ ] Transform page links to plain markdown links (next-up)
+- [ ] Replace tildes and ñ instead of removing them (next-up)
 - [ ] Show all the pages linking to the current one (on the roadmap)
 - [ ] Link to blocks (on the roadmap)
 

--- a/src/gitbook.js
+++ b/src/gitbook.js
@@ -5,7 +5,7 @@ const summarize = require('./gitbook/summary');
 // const obsidianToMD = require('./gitbook/obsidian');
 
 /* Load settings (if exist) */
-const settings = require('settings.js');
+const settings = require('./settings.js');
 
 
 /**

--- a/src/gitbook.js
+++ b/src/gitbook.js
@@ -2,7 +2,8 @@ const copyProject = require('./gitbook/copy');
 const indexProject = require('./gitbook/index-project');
 const renameProject = require('./gitbook/rename');
 const summarize = require('./gitbook/summary');
-// const obsidianToMD = require('./gitbook/obsidian');
+
+const parseLinks = require('./obsidian-md/parse-links');
 
 /* Load settings (if exist) */
 const settings = require('./settings.js');
@@ -47,6 +48,9 @@ async function main() {
 
   /* Convert the Obsidian syntax to markdown */
   // obsidianToMd(index);
+
+  /* Parse page links */
+  const pageIndex = parseLinks(settings.gitbookProject, index);
 
   return true
 }

--- a/src/gitbook.js
+++ b/src/gitbook.js
@@ -5,17 +5,7 @@ const summarize = require('./gitbook/summary');
 // const obsidianToMD = require('./gitbook/obsidian');
 
 /* Load settings (if exist) */
-let settings = {
-  obsidianProject: '../obsidian',
-  gitbookProject: '../gitbook',
-};
-
-try {
-  settings = require('../settings.json');
-  console.log('Settings loaded from settings.json');
-} catch {
-  console.log('Settings not found. Using default settings');
-}
+const settings = require('settings.js');
 
 
 /**
@@ -34,6 +24,8 @@ async function main() {
   /* Build an index of the project files */
   const index = await indexProject(settings.gitbookProject);
   // console.log(index)
+
+  /* ToDo: Remove unneccessary files and folders (.gitignore, .gitatributes, .git...) */
 
   /* Rename the files and folders */
   const renamed = await renameProject(settings.gitbookProject, index);

--- a/src/gitbook/copy.js
+++ b/src/gitbook/copy.js
@@ -17,7 +17,12 @@ async function copyProject(obsidian, gitbook) {
     console.log('> Removed Obsidian files');
 
     // Remove Git files
-    const gitPaths = ['.git', '.gitignore', '.gitattributes'];
+    const gitPaths = [
+      '.git',
+      '.gitignore',
+      '.gitattributes',
+      '.github',
+    ];
 
     for (var i = 0; i < gitPaths.length; i++) {
       const path = gitPaths[i];

--- a/src/gitbook/copy.js
+++ b/src/gitbook/copy.js
@@ -16,6 +16,22 @@ async function copyProject(obsidian, gitbook) {
     await fse.remove(`${gitbook}/.obsidian`);
     console.log('> Removed Obsidian files');
 
+    // Remove Git files
+    const gitPaths = ['.git', '.gitignore', '.gitattributes'];
+
+    // gitPaths.forEach(async (path) => {
+    for (var i = 0; i < gitPaths.length; i++) {
+      const path = gitPaths[i];
+      
+      const fullPath = `${gitbook}/${path}`;
+      const exists = await fse.pathExists(fullPath);
+      if (exists) {
+        await fse.remove(fullPath);
+      }
+    // })
+    }
+    console.log('> Removed Git-related files');
+
     return true;
   } catch (e) {
     console.error('> Error copying Obsidian project to GitBook folder');

--- a/src/gitbook/copy.js
+++ b/src/gitbook/copy.js
@@ -19,16 +19,14 @@ async function copyProject(obsidian, gitbook) {
     // Remove Git files
     const gitPaths = ['.git', '.gitignore', '.gitattributes'];
 
-    // gitPaths.forEach(async (path) => {
     for (var i = 0; i < gitPaths.length; i++) {
       const path = gitPaths[i];
-      
+
       const fullPath = `${gitbook}/${path}`;
       const exists = await fse.pathExists(fullPath);
       if (exists) {
         await fse.remove(fullPath);
       }
-    // })
     }
     console.log('> Removed Git-related files');
 

--- a/src/obsidian-md/parse-links.js
+++ b/src/obsidian-md/parse-links.js
@@ -98,10 +98,12 @@ async function parsePageLinks(filename, index) {
     for (let i = 0; i < uniqueLinks.length; i += 1) {
       const pageName = uniqueLinks[i].replace('[[', '').replace(']]', '');
       const pageLinkPath = pageLink(pageName, index);
-      const mdlink = `[${pageName}](${pageLinkPath})`
+
+      // In GitBook, relative links to the book are preceded by ../
+      const gitbookLink = `[${pageName}](../${pageLinkPath})`
       
       // Unable to use .replace() with RegEx because of [] chars
-      pageText = pageText.split(uniqueLinks[i]).join(mdlink);
+      pageText = pageText.split(uniqueLinks[i]).join(gitbookLink);
     }
 
     // ...And store the new file

--- a/src/obsidian-md/parse-links.js
+++ b/src/obsidian-md/parse-links.js
@@ -99,8 +99,37 @@ async function parsePageLinks(filename, index) {
       const pageName = uniqueLinks[i].replace('[[', '').replace(']]', '');
       const pageLinkPath = pageLink(pageName, index);
 
+      // ToDo: If not link found, act in consequence
+      if (!pageLinkPath) {
+        console.warn(`[warn] Unable to find link for ${pageName}`);
+        break;
+      }
+
       // In GitBook, relative links to the book are preceded by ../
-      const gitbookLink = `[${pageName}](../${pageLinkPath})`
+      /*
+        ToDo:
+        In nested folders, internal links are not working. 
+        It might be related to the ../ at the begining.
+        Maybe trying to use as may ../ as levels are in the path?
+         -> (check src/gitbook/summary.md).
+      */
+      const depth = pageLinkPath.split('/').length - 1;
+      
+      // Initial depth of '0'
+      let pageDepth = './';
+      
+      if (depth > 0) {
+        // Reset page depth
+        pageDepth = '';
+        
+        // And add the nested levels required
+        for (let j = 0; j < depth; j += 1) {
+          pageDepth += '../';
+        }
+      }
+
+      const gitbookLink = `[${pageName}](${pageDepth}${pageLinkPath})`
+      // console.log(pageDepth, pageLinkPath);
       
       // Unable to use .replace() with RegEx because of [] chars
       pageText = pageText.split(uniqueLinks[i]).join(gitbookLink);
@@ -142,11 +171,11 @@ async function parseLinks(folder, index, rootIndex) {
       }
 
       // Parse page links
-      console.log(`~~> ${folder}/${nodes[i]}`)
+      // console.log(`~~> ${folder}/${nodes[i]}`)
       await parsePageLinks(`${folder}/${nodes[i]}`, originalIndex);
     }
 
-    console.log('> First level page links created!');
+    // console.log('> First level page links created!');
 
     return pageLinks;
   } catch (e) {

--- a/src/obsidian-md/parse-links.js
+++ b/src/obsidian-md/parse-links.js
@@ -1,0 +1,157 @@
+const fs = require('fs');
+const fse = require('fs-extra');
+
+const indexProject = require('../gitbook/index-project');
+
+// Page links map
+const pageLinks = {};
+
+/**
+ *  Get page name from original filename
+ * 
+ *  @param filename {String} Filename to turn into page name
+ *  @return {String} Page name (without stuff like extensions)
+ */
+function pageName(filename) {
+  return filename.replace('.md', '');
+}
+
+/**
+ *  Search for page link in node index
+ * 
+ *  @param page {String} Page name to find link
+ *  @param index {Object} Project index to find into
+ *  @return {String} Path to the page
+ */
+function findPageLink(page, index) {
+  const nodes = Object.keys(index);
+  
+  // ToDo: Is there a / in page name? 
+
+  for (let i = 0; i < nodes.length; i += 1) {
+    const node = index[nodes[i]];
+
+    // Deep search in folders
+    if (typeof node.content !== 'undefined') {
+      const found = findPageLink(page, node.content);
+
+      if (found) {
+        return `${nodes[i]}/${found}`;
+      }
+    }
+
+    // Check page name
+    if (pageName(node.name) === page) {
+      return nodes[i];
+    }
+  }
+
+  return false;
+}
+
+/**
+ *  Get a page link
+ * 
+ *  @param page {String} Page name to find link
+ *  @param index {Object} Project index to find into
+ *  @return {String} Path to the page
+ */
+function pageLink(page, index) {
+  if (pageLinks[page]) {
+    return pageLinks[page];
+  }
+
+  const link = findPageLink(page, index);
+  pageLinks[page] = link;
+  
+  return link;
+}
+
+/**
+ *  Parse page links in a file
+ */
+async function parsePageLinks(filename, index) {
+  try {
+    // If is not a markdown file, jump to the next file
+    if (filename.indexOf('.md') === -1) {
+      // console.log('File is not markdown. Skipping.');
+      return false;
+    }
+
+    // If file dont exist, jump to the next file
+    const exists = await fse.pathExists(filename);
+    if (!exists) {
+      return false;
+    }
+
+    // Get page content
+    let pageText = fs.readFileSync(filename, 'utf8');
+
+    // If not content, jump. It might be an empty page.
+
+    // Regex: Find "[[ SOMETHING ]]" (without quotes)
+    const pageLinkRegex = /(\[\[)(\s*\b)([^\[\]]*)(\b\s*)(\]\])/g;
+    const links = pageText.match(pageLinkRegex);
+    const uniqueLinks = [...new Set(links)];
+
+    // If links, replace them...
+    for (let i = 0; i < uniqueLinks.length; i += 1) {
+      const pageName = uniqueLinks[i].replace('[[', '').replace(']]', '');
+      const pageLinkPath = pageLink(pageName, index);
+      const mdlink = `[${pageName}](${pageLinkPath})`
+      
+      // Unable to use .replace() with RegEx because of [] chars
+      pageText = pageText.split(uniqueLinks[i]).join(mdlink);
+    }
+
+    // ...And store the new file
+    fs.writeFileSync(filename, pageText);
+
+  } catch (err) {
+    console.error(err)
+  }
+}
+
+/**
+ *  Parse links in all pages for a given index
+ * 
+ *  @param index {Object} Project index to find into
+ */
+async function parseLinks(folder, index, rootIndex) {
+  let newIndex = { ...index };
+  let originalIndex = { ...rootIndex }
+
+  if (!index) {
+    newIndex = indexProject(folder);
+  }
+  if (!rootIndex) {
+    originalIndex = newIndex;
+  }
+
+  try {
+    const nodes = Object.keys(newIndex);
+
+    for (let i = 0; i < nodes.length; i += 1) {
+      const node = newIndex[nodes[i]];
+
+      // If is folder, go recursive
+      if (typeof node.content !== 'undefined') {
+        await parseLinks(`${folder}/${nodes[i]}`, node.content, originalIndex);  
+      }
+
+      // Parse page links
+      console.log(`~~> ${folder}/${nodes[i]}`)
+      await parsePageLinks(`${folder}/${nodes[i]}`, originalIndex);
+    }
+
+    console.log('> First level page links created!');
+
+    return pageLinks;
+  } catch (e) {
+    console.error('Error: Unable to rewrite Obsidian page links');
+    console.error(e);
+    return null;
+  }
+}
+
+module.exports = parseLinks;

--- a/src/obsidian-md/parse-links.js
+++ b/src/obsidian-md/parse-links.js
@@ -113,7 +113,10 @@ async function parsePageLinks(filename, index) {
         Maybe trying to use as may ../ as levels are in the path?
          -> (check src/gitbook/summary.md).
       */
-      const depth = pageLinkPath.split('/').length - 1;
+      
+      // ToDo: Make this dynamic based on the orifinal fonder parsed
+      const originDepth = '../gitbook/'.split('/').length;
+      const depth = (filename.split('/').length - 1) - originDepth;
       
       // Initial depth of '0'
       let pageDepth = './';
@@ -129,7 +132,7 @@ async function parsePageLinks(filename, index) {
       }
 
       const gitbookLink = `[${pageName}](${pageDepth}${pageLinkPath})`
-      // console.log(pageDepth, pageLinkPath);
+      // console.log(filename, pageDepth, pageLinkPath);
       
       // Unable to use .replace() with RegEx because of [] chars
       pageText = pageText.split(uniqueLinks[i]).join(gitbookLink);

--- a/src/obsidian-md/parse-links.js
+++ b/src/obsidian-md/parse-links.js
@@ -113,10 +113,10 @@ async function parsePageLinks(filename, index) {
         Maybe trying to use as may ../ as levels are in the path?
          -> (check src/gitbook/summary.md).
       */
-      
+
       // ToDo: Make this dynamic based on the orifinal fonder parsed
       const originDepth = '../gitbook/'.split('/').length;
-      const depth = (filename.split('/').length - 1) - originDepth;
+      const depth = filename.split('/').length - originDepth;
       
       // Initial depth of '0'
       let pageDepth = './';
@@ -133,6 +133,7 @@ async function parsePageLinks(filename, index) {
 
       const gitbookLink = `[${pageName}](${pageDepth}${pageLinkPath})`
       // console.log(filename, pageDepth, pageLinkPath);
+      console.log(filename, depth, pageDepth);
       
       // Unable to use .replace() with RegEx because of [] chars
       pageText = pageText.split(uniqueLinks[i]).join(gitbookLink);

--- a/src/settings.js
+++ b/src/settings.js
@@ -1,0 +1,19 @@
+let settings = {
+  obsidianProject: '../obsidian',
+  gitbookProject: '../gitbook',
+};
+
+try {
+  const settingsFile = require('./settings.json');
+
+  settings = {
+    ...settings,
+    ...settingsFile,
+  };
+  console.log('Custom settings loaded from settings.json');
+} catch {
+  console.log('Settings not found. Using default settings');
+}
+
+// export default settings;
+module.exports = settings;


### PR DESCRIPTION
Initial version of the Obsidian Link Parser.

It maps the Obsidian references to a page with the page path, and replaces it with a relative page link.

Known Issues:
- **It does not understand page references with `/`**.
This happens in Obsidian when there's two files with the same name in different folders (`Example` and `Resources/Example`), to specify the page you want to link (`[[Example]]` or `[[Resources/Example]]`)
- **Root level for files is hard-coded**.
 I have to review the project structure, and make it all dependent of `settings.js` file, instead of passing configs through functions. This will improve readability, and will add cohesion to the library.

I have a test deploy (https://carlos-hernandez-1.gitbook.io/untitled/empezar) with a pretty complex Obsidian Vault (https://github.com/recursosdisenoes/recursos-diseno-es/) so I can test that everything works as expeced.

In case you find something wrong there, let me know in this PR.

I will try to fix the known issues list before merging this.